### PR TITLE
Fix playerWhoWasVotedFor being undefined due to invalid operator.

### DIFF
--- a/src/sockets/handleGuess.ts
+++ b/src/sockets/handleGuess.ts
@@ -26,7 +26,7 @@ async function handleGuess(
       (player: any) => player.id === socket.id
     );
     const playerWhoWasVotedFor = lobbies[lobbyCode].players.find(
-      (player: any) => player.id === guess
+      (player: any) => player.definitionId === Number(guess)
     );
     // add vote
     // console.log(lobbies[lobbyCode])


### PR DESCRIPTION
Previous operator was comparing player ID (number) against guess ID (string) and finding no matches. New operator finds the player with the same definition ID as the guess.