### PR TITLE
Add check to make sure num is defined.

### DIFF
--- a/src/api/words/utils.ts
+++ b/src/api/words/utils.ts
@@ -37,7 +37,7 @@ export function range(n:number) {
  */
 export function validNumber(num:any) {
   const pattern = /[0-9]/g;
-  const result = num.match(pattern)
+  const result = num?.match(pattern);
   const n:string = result?.length > 0 && result?.length === num?.length ? result.join("") : "";
   return n.length > 0;
 }


### PR DESCRIPTION
- Add check on 'num' in validNumber function to ensure it's defined
 
Hitting the /api/words/scoop/ endpoint was resulting in a "TypeError: Cannot read property 'match' of undefined".
This quick fix ensures that 'num' is defined before attempting to read 'num.match'
Fixes issue with crashing and allows client to get words